### PR TITLE
makes parity with native filter function

### DIFF
--- a/src/content/array-filter/array-filter.mdx
+++ b/src/content/array-filter/array-filter.mdx
@@ -33,7 +33,7 @@ Implement the `Array.filter` method
 Array.prototype.newFilter = function (callback, context) {
   const result = [];
   for (let index = 0; index < this.length; index++) {
-    if (callback.call(context, this[index], index, this)) {
+    if (callback.call(context, this[index], index, this) && this.indexOf(this[index]) > -1) {
       result.push(this[index])
     }
   }


### PR DESCRIPTION
**What was the issue?**
The `newFilter` method allows undefined values to be part of the filtered array but the native implementation removes that.

**How to replicate it?**
Add `numbers[7] = 9` and change condition to filter odd numbers and you will find out that it doesn't filter empty/undefined values in the array. 

numbers array would be - 

```
const numbers = [1, 2, 3, 4, undefined, undefined, undefined, 9]
```

**What is the reason?**
When we call `callback.call(context, this[index], index, this)` for undefined value then it produces `true` and it pushes the value to `result` array.

```
undefined => undefined % 2 !== 0 // produces `true`
```
**How to prevent it?**
We need to put a guard condition to only allow values that are actually part of the array and not produced artificially. The proposed condition makes sure that it matches with native `.filter` output.

